### PR TITLE
Add opencode workflow; fix ai suggestion parsing

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/kimi-k2.5-free

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -233,7 +233,7 @@ function parseEvaluationResponse(response: string): EvaluationResult {
         } else if (lower.startsWith('suggestions:')) {
             inSuggestions = true;
         } else if (inSuggestions && (line.startsWith('-') || line.startsWith('•') || line.match(/^\d+\./))) {
-            const suggestion = line.replace(/^[-•\d]+\.\s*/, '').trim();
+            const suggestion = line.replace(/^[-•\d]+\.\s*|^-\s+/, '').trim();
             if (suggestion) suggestions.push(suggestion);
         }
     }


### PR DESCRIPTION
Add a new GitHub Actions workflow (.github/workflows/opencode.yml) that runs the anomalyco/opencode action when issue or PR review comments include `/oc` or `/opencode`. The workflow checks out the repo and provides OPENCODE_API_KEY via secrets.

Fix parsing in src/lib/ai.ts to strip plain hyphen bullets when collecting suggestions by updating the regex to also remove leading `- ` (in addition to numbered or dot bullets), preventing leftover hyphens in suggestion text.