### PR TITLE
Fix favicon not visible on deployment

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#546e7a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2 6h4"/>
+  <path d="M2 10h4"/>
+  <path d="M2 14h4"/>
+  <path d="M2 18h4"/>
+  <rect width="16" height="20" x="4" y="2" rx="2"/>
+  <path d="M8 18h.01"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,6 @@ const ibmPlexMono = IBM_Plex_Mono({
 export const metadata: Metadata = {
   title: "Kitaab",
   description: "Privacy-first, local-first markdown editor with real-time writing analysis",
-  icons: {
-    icon: "/favicon.svg",
-  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
Uses Next.js file-based metadata convention by adding `icon.svg` in the app directory. This automatically makes the SVG available as the favicon without requiring explicit metadata declaration.

## Changes
- Added `src/app/icon.svg`: Notebook/journal icon matching the project's primary color
- Removed explicit `icons` metadata from `layout.tsx`

## Testing
Favicon should now be visible on deployment at `/icon.svg` and display in the browser tab.