### PR TITLE
Add Cloudflare Web Analytics integration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, IBM_Plex_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { ToastProvider } from "@/components/ui/ToastProvider";
 
@@ -52,6 +53,12 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href={EDITOR_FONTS_URL} rel="stylesheet" />
+        {/* Cloudflare Web Analytics */}
+        <Script
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "50e0b52f5a474c81863041630e53e753"}'
+        />
       </head>
       <body
         className={`${inter.variable} ${ibmPlexMono.variable} antialiased`}


### PR DESCRIPTION
Integrate Cloudflare Web Analytics beacon script into the root layout to enable analytics tracking across the application.

The analytics token is configured via the Cloudflare beacon script component, which is deferred to avoid blocking page rendering.

Closes #47